### PR TITLE
Make sure CMake is passing -std=c++17 to the compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,3 @@
+set(CMAKE_CXX_STANDARD 17)
+
 add_executable (a.out main.cpp)


### PR DESCRIPTION
Projects wasn't compiling out of the box for me. This fixes build issues where <variant> isn't found.